### PR TITLE
Added CORS support to context service

### DIFF
--- a/smart-on-fhir-spi/README.md
+++ b/smart-on-fhir-spi/README.md
@@ -6,6 +6,11 @@ Service Provider Interface (SPI) java module to Keycloak.
 
 ```mvn clean package```
 
+
+## skip tests
+
+```mvn -B -DskipTests clean package```
+
 ### check pom.xml for package updates.
 
 ```mvn versions:display-dependency-updates```

--- a/smart-on-fhir-spi/pom.xml
+++ b/smart-on-fhir-spi/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <gpg.skip>true</gpg.skip>
         <java.version>11</java.version>
-        <keycloak.version>26.2.2</keycloak.version>
+        <keycloak.version>26.3.5</keycloak.version>
         <commons-io.version>2.17.0</commons-io.version>
         <junit.version>4.13.2</junit.version>
         <org.junit.jupiter.version>5.11.3</org.junit.jupiter.version>


### PR DESCRIPTION
Fixes missing CORS management for preflight when using context service from a browser. Up to now, it only worked on backend services, not originating from browser.  This fixes that issue.